### PR TITLE
feat(repository): Add sensitive flag to policy_revision output

### DIFF
--- a/modules/repository/outputs.tf
+++ b/modules/repository/outputs.tf
@@ -21,6 +21,7 @@ output "repository_domain_owner" {
 output "policy_revision" {
   description = "The revision of the repository permissions policy. Only set if a policy is created."
   value       = local.create_policy ? aws_codeartifact_repository_permissions_policy.this[0].policy_revision : null
+  sensitive   = true
 }
 
 output "is_enabled" {


### PR DESCRIPTION
- Added the `sensitive` flag to the `policy_revision` output to prevent the policy revision from being displayed in plaintext.
- This ensures sensitive information in the policy revision is not exposed.