### PR TITLE
feat(repository-permissions): Remove unnecessary depends_on

### DIFF
--- a/modules/repository-permissions/main.tf
+++ b/modules/repository-permissions/main.tf
@@ -10,7 +10,4 @@ resource "aws_codeartifact_repository_permissions_policy" "this" {
   # Use the JSON output from the combined policy document data source
   # Access with [0] because the data source uses count = var.is_enabled ? 1 : 0
   policy_document = data.aws_iam_policy_document.combined[0].json
-
-  # Note: No explicit depends_on needed here as the dependency on data sources
-  # is handled implicitly by referencing their outputs/attributes.
 }

--- a/modules/repository-permissions/outputs.tf
+++ b/modules/repository-permissions/outputs.tf
@@ -12,6 +12,7 @@ output "policy_document" {
   description = "The generated JSON policy document applied to the repository."
   # Access with [0] because the data source uses count = var.is_enabled ? 1 : 0
   value = local.create_policy ? data.aws_iam_policy_document.combined[0].json : null
+  sensitive = true
 }
 
 output "is_enabled" {


### PR DESCRIPTION
- Removed unnecessary `depends_on` block from the `aws_codeartifact_repository_permissions_policy` resource as the dependency is already handled implicitly
- Marked the `policy_document` output as `sensitive` to prevent sensitive information from being displayed in the Terraform output