### PR TITLE
feat(repository-permissions): Update policy document output

### DIFF
--- a/modules/repository-permissions/outputs.tf
+++ b/modules/repository-permissions/outputs.tf
@@ -11,7 +11,7 @@ output "resource_arn" {
 output "policy_document" {
   description = "The generated JSON policy document applied to the repository."
   # Access with [0] because the data source uses count = var.is_enabled ? 1 : 0
-  value = local.create_policy ? data.aws_iam_policy_document.combined[0].json : null
+  value     = local.create_policy ? data.aws_iam_policy_document.combined[0].json : null
   sensitive = true
 }
 


### PR DESCRIPTION
The changes update the `policy_document` output in the
`repository-permissions` module. The `value` attribute is now
explicitly set to the `json` attribute of the `data.aws_iam_policy_document.combined[0]`
resource, which ensures the output is always a valid JSON string.