### PR TITLE
fix/bucket-policies

### DIFF
--- a/modules/foundation/locals.tf
+++ b/modules/foundation/locals.tf
@@ -115,8 +115,6 @@ locals {
     }
   )
 
-  # S3 bucket name configuration with domain name integration
-  bucket_name = var.bucket_name != null ? var.bucket_name : "codeartifact-${local.codeartifact_domain_name}-${data.aws_caller_identity.current.account_id}"
 
   # S3 bucket policy configuration
   default_bucket_policy_statement = {
@@ -125,11 +123,11 @@ locals {
     actions = ["s3:GetObject", "s3:ListBucket"]
     principals = {
       type        = "AWS"
-      identifiers = [data.aws_caller_identity.current.account_id]
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"] # Fixed: ARN format
     }
     resources = [
-      "arn:aws:s3:::${local.bucket_name}",
-      "arn:aws:s3:::${local.bucket_name}/*"
+      "arn:aws:s3:::${var.s3_bucket_name}",
+      "arn:aws:s3:::${var.s3_bucket_name}/*"
     ]
   }
 
@@ -145,14 +143,16 @@ locals {
     Statement = [
       for statement in local.bucket_policy_statements : merge(
         {
-          Sid       = statement.sid
-          Effect    = statement.effect
-          Principal = statement.principals
-          Action    = statement.actions
-          Resource  = statement.resources
+          Sid    = statement.sid
+          Effect = statement.effect
+          Principal = {
+            # Format Principal correctly - always use list type for consistency
+            "${statement.principals.type}" = statement.principals.identifiers
+          }
+          Action   = statement.actions
+          Resource = statement.resources
         },
-        # Only include Condition if it exists in the statement
-        try({ Condition = statement.condition }, {})
+        statement.condition != null ? { Condition = statement.condition } : {}
       )
     ]
   })

--- a/modules/foundation/locals.tf
+++ b/modules/foundation/locals.tf
@@ -152,7 +152,7 @@ locals {
           Action   = statement.actions
           Resource = statement.resources
         },
-        statement.condition != null ? { Condition = statement.condition } : {}
+        try(statement.condition, null) != null ? { Condition = try(statement.condition, null) } : {}
       )
     ]
   })

--- a/modules/foundation/main.tf
+++ b/modules/foundation/main.tf
@@ -23,13 +23,7 @@ resource "aws_kms_key" "this" {
   enable_key_rotation     = true
   policy                  = local.kms_key_policy
 
-  tags = merge(
-    local.common_tags,
-    {
-      Name       = "codeartifact-${local.codeartifact_domain_name}-encryption-key"
-      DomainName = local.codeartifact_domain_name
-    }
-  )
+  tags = local.common_tags
 }
 
 resource "aws_kms_alias" "this" {
@@ -73,13 +67,13 @@ resource "aws_cloudwatch_log_group" "this" {
 resource "aws_s3_bucket" "this" {
   count = local.is_s3_bucket_enabled ? 1 : 0
 
-  bucket        = coalesce(var.s3_bucket_name, local.bucket_name)
+  bucket        = var.s3_bucket_name
   force_destroy = var.force_destroy_bucket
 
   tags = merge(
     local.common_tags,
     {
-      Name       = coalesce(var.s3_bucket_name, local.bucket_name)
+      Name       = var.s3_bucket_name
       DomainName = local.codeartifact_domain_name
     }
   )

--- a/modules/foundation/modules/foundation/CHANGELOG.md
+++ b/modules/foundation/modules/foundation/CHANGELOG.md
@@ -1,8 +1,0 @@
-# Changelog
-
-## [0.1.1](https://github.com/Excoriate/terraform-aws-codeartifact/compare/v0.1.0...v0.1.1) (2025-04-14)
-
-
-### ✨ Features
-
-* **domain:** Add output for domain S3 bucket ARN ([#13](https://github.com/Excoriate/terraform-aws-codeartifact/issues/13)) ([985fbbc](https://github.com/Excoriate/terraform-aws-codeartifact/commit/985fbbc0bfb9990b1e8a0c19c09f74e2632e4084))


### PR DESCRIPTION
- Simplifies the S3 bucket configuration and policy
- Removes the dynamic bucket name generation and uses the provided `s3_bucket_name` variable
- Ensures the Condition block is only included if it exists in the statement
- Improves the S3 bucket policy configuration by fixing the ARN format and simplifying the formatting of the `bucket_policy_statements` local